### PR TITLE
Fix spelling of "Canadian" in _quarto.yml

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,7 +3,7 @@ project:
   output-dir: docs
 
 book:
-  title: "Analyzing Candian Demographic and Housing Data"
+  title: "Analyzing Canadian Demographic and Housing Data"
   author: "Jens von Bergmann"
   date: "2022-04-01"
   description: "Building skills and community to analyse Canadian demographic and housing data."


### PR DESCRIPTION
The "Candian" spelling shows up in quite a few files, but at quick glance most of them seemed to be generated—rather than re-run the generation myself, I figured I’d just fix the `.yml` on assumption that you’d rebuild the book at some point. Great project!